### PR TITLE
Allow alternative buffer sizes for inference.

### DIFF
--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedError.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedError.scala
@@ -10,7 +10,14 @@ package net.tixxit.delimited
  * @param row      the row (1-based) where the error occured
  * @param col      the column (1-based) where the error occured
  */
-case class DelimitedError(message: String, rowStart: Long, pos: Long, context: String, row: Long, col: Long) {
+case class DelimitedError(
+  message: String,
+  rowStart: Long,
+  pos: Long,
+  context: String,
+  row: Long,
+  col: Long
+) extends Exception(message) {
 
   /**
    * A helpful, nicely rendered, multiline message that is suitable for human

--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
@@ -134,6 +134,10 @@ object DelimitedParser {
    * Returns a `DelimitedParser` that can parse delimited files using the
    * strategy or format provided.
    */
-  def apply(format: DelimitedFormatStrategy): DelimitedParser =
-    parser.DelimitedParserImpl(format)
+  def apply(
+    format: DelimitedFormatStrategy,
+    bufferSize: Int = BufferSize
+  ): DelimitedParser = {
+    parser.DelimitedParserImpl(format, bufferSize)
+  }
 }

--- a/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
+++ b/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
@@ -66,11 +66,12 @@ object Delimited {
    * @param format the strategy to use while parsing the delimited file
    */
   final def parseString[F[_]](
-    format: DelimitedFormatStrategy
+    format: DelimitedFormatStrategy,
+    bufferSize: Int = DelimitedParser.BufferSize
   )(implicit F: Applicative[F]): Enumeratee[F, String, Row] = {
     new Enumeratee[F, String, Row] {
       def apply[A](step: Step[F, Row, A]): F[Step[F, String, Step[F, Row, A]]] =
-        F.pure(doneOrLoop(DelimitedParser(format))(step))
+        F.pure(doneOrLoop(DelimitedParser(format, bufferSize))(step))
 
       private[this] def doneOrLoop[A](parser: DelimitedParser)(step: Step[F, Row, A]): Step[F, String, Step[F, Row, A]] = {
         if (step.isDone) {


### PR DESCRIPTION
This allows a user to pass through their own "buffer size" to use when inferring a delimited format. This is, roughly, a lower bound on the amount of data that'll be buffered before attempting to infer the format.