### PR TITLE
Add maxCharsPerRow parameter for parsing.

### DIFF
--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedError.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedError.scala
@@ -30,4 +30,7 @@ case class DelimitedError(
 
     s"$msg\n\n$context\n$pointer"
   }
+
+  override def toString: String =
+    s"DelimitedError($message, rowStart = $rowStart, pos = $pos, context = $context, row = $row, col = $col)"
 }

--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
@@ -133,11 +133,17 @@ object DelimitedParser {
   /**
    * Returns a `DelimitedParser` that can parse delimited files using the
    * strategy or format provided.
+   *
+   * @param format         strategy used to determine the format
+   * @param bufferSize     minimum size of buffer used for format inference
+   * @param maxCharsPerRow hard limit on the # of chars in a row, or 0 if there
+   *                       is no limit
    */
   def apply(
     format: DelimitedFormatStrategy,
-    bufferSize: Int = BufferSize
+    bufferSize: Int = BufferSize,
+    maxCharsPerRow: Int = 0
   ): DelimitedParser = {
-    parser.DelimitedParserImpl(format, bufferSize)
+    parser.DelimitedParserImpl(format, bufferSize, maxCharsPerRow)
   }
 }

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
@@ -61,7 +61,7 @@ final case class DelimitedParserImpl(
 
       instr match {
         case EmitRow(cells) =>
-          if (maxCharsPerRow > 0 && (s1.rowStart - s0.rowStart) > maxCharsPerRow) {
+          if (maxCharsPerRow > 0 && (s1.rowStart - s0.rowStart - maxRowDelimLength) > maxCharsPerRow) {
               val context = DelimitedParserImpl.removeRowDelim(format,
                 s1.input.substring(s0.rowStart, s1.rowStart))
             val error = DelimitedError(s"row exceeded maximum length of $maxCharsPerRow",

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
@@ -17,8 +17,11 @@ final case class DelimitedParserImpl(
   parserState: ParserState,
   fail: Option[Fail],
   row: Long,
-  bufferSize: Int
+  bufferSize: Int,
+  maxCharsPerRow: Int
 ) extends DelimitedParser {
+  require(maxCharsPerRow >= 0, "max row characters parameter must be non-negative")
+
   def format: Option[DelimitedFormat] = strategy match {
     case (fmt: DelimitedFormat) => Some(fmt)
     case _ => None
@@ -26,7 +29,7 @@ final case class DelimitedParserImpl(
 
   def reset: (String, DelimitedParserImpl) = {
     val in = parserState.input
-    (in.substring(in.mark, in.limit), DelimitedParserImpl(strategy, bufferSize))
+    (in.substring(in.mark, in.limit), DelimitedParserImpl(strategy, bufferSize, maxCharsPerRow))
   }
 
   def parseChunk(chunk: Option[String]): (DelimitedParserImpl, Vector[Either[DelimitedError, Row]]) = {
@@ -41,10 +44,15 @@ final case class DelimitedParserImpl(
           guess(initState.input.data)
         } else {
           // TODO: We could get rid of this return.
-          return (DelimitedParserImpl(strategy, initState, fail, row, bufferSize), Vector.empty)
+          return (DelimitedParserImpl(strategy, initState, fail, row, bufferSize, maxCharsPerRow), Vector.empty)
         }
       case (fmt: DelimitedFormat) =>
         fmt
+    }
+
+    val maxRowDelimLength: Int = format.rowDelim match {
+      case RowDelim(value, None) => value.length
+      case RowDelim(value, Some(alt)) => scala.math.max(value.length, alt.length)
     }
 
     @tailrec
@@ -53,7 +61,15 @@ final case class DelimitedParserImpl(
 
       instr match {
         case EmitRow(cells) =>
-          loop(s1, fail, row + 1, acc :+ Right(cells))
+          if (maxCharsPerRow > 0 && (s1.rowStart - s0.rowStart) > maxCharsPerRow) {
+              val context = DelimitedParserImpl.removeRowDelim(format,
+                s1.input.substring(s0.rowStart, s1.rowStart))
+            val error = DelimitedError(s"row exceeded maximum length of $maxCharsPerRow",
+              s0.rowStart, s0.rowStart, context, row, 1)
+            loop(s1, fail, row + 1, acc :+ Left(error))
+          } else {
+            loop(s1, fail, row + 1, acc :+ Right(cells))
+          }
 
         case f @ Fail(_, _) =>
           loop(s1, Some(f), row, acc)
@@ -70,10 +86,16 @@ final case class DelimitedParserImpl(
           }
 
         case NeedInput =>
-          DelimitedParserImpl(format, s1, fail, row, bufferSize) -> acc
+          if (maxCharsPerRow > 0 && fail.isEmpty &&
+              (s1.input.limit - s1.rowStart - maxRowDelimLength) > maxCharsPerRow) {
+            val f = Some(Fail(s"row exceeded maximum length of $maxCharsPerRow", s1.rowStart))
+            DelimitedParserImpl(format, s1.skipRow, f, row, bufferSize, maxCharsPerRow) -> acc
+          } else {
+            DelimitedParserImpl(format, s1, fail, row, bufferSize, maxCharsPerRow) -> acc
+          }
 
         case Done =>
-          DelimitedParserImpl(format, s1, None, row, bufferSize) -> acc
+          DelimitedParserImpl(format, s1, None, row, bufferSize, maxCharsPerRow) -> acc
       }
     }
 
@@ -82,11 +104,22 @@ final case class DelimitedParserImpl(
 }
 
 object DelimitedParserImpl {
+
+  /**
+   * Returns a new DelimitedParserImpl whose state is initially empty.
+   *
+   * @note If `maxRowsChars` is 0, then there is no limit on row size.
+   *
+   * @param format the format strategy to use for parsing
+   * @param bufferSize the minimum size of the buffer to use for format inference
+   * @param maxRowsChars a hard limit on the allowable size of a row
+   */
   def apply(
     format: DelimitedFormatStrategy,
-    bufferSize: Int
+    bufferSize: Int,
+    maxCharsPerRow: Int
   ): DelimitedParserImpl = {
-    DelimitedParserImpl(format, ParserState.ParseRow(0L, 0L, Input.init("")), None, 1L, bufferSize)
+    DelimitedParserImpl(format, ParserState.ParseRow(0L, 0L, Input.init("")), None, 1L, bufferSize, maxCharsPerRow)
   }
 
   def parse(format: DelimitedFormat)(state: ParserState): (ParserState, Instr) = {

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/ParserState.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/ParserState.scala
@@ -23,6 +23,8 @@ sealed trait ParserState {
   }
 
   def mapInput(f: Input => Input): ParserState = withInput(f(input))
+
+  def skipRow: ParserState = SkipRow(rowStart, readFrom, input, sizeHint)
 }
 
 object ParserState {

--- a/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedErrorSpec.scala
+++ b/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedErrorSpec.scala
@@ -16,4 +16,11 @@ class DelimitedErrorSpec extends WordSpec with Matchers with Checkers {
           |  ^""".stripMargin
     }
   }
+
+  "toString" should {
+    "include location info" in {
+      val error = DelimitedError("blah", 4, 32, "qwerty", 99, 88)
+      error.toString shouldBe "DelimitedError(blah, rowStart = 4, pos = 32, context = qwerty, row = 99, col = 88)"
+    }
+  }
 }

--- a/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
+++ b/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
@@ -63,15 +63,19 @@ object Delimited {
    * An [[Enumeratee]] that parses chunks of character data from a delimited
    * file into [[Row]]s.
    *
-   * @param format the strategy to use while parsing the delimited file
+   * @param format         strategy used to determine the format
+   * @param bufferSize     minimum size of buffer used for format inference
+   * @param maxCharsPerRow hard limit on the # of chars in a row, or 0 if there
+   *                       is no limit
    */
   final def parseString[F[_]](
     format: DelimitedFormatStrategy,
-    bufferSize: Int = DelimitedParser.BufferSize
+    bufferSize: Int = DelimitedParser.BufferSize,
+    maxCharsPerRow: Int = 0
   )(implicit F: Applicative[F]): Enumeratee[F, String, Row] = {
     new Enumeratee[F, String, Row] {
       def apply[A](step: Step[F, Row, A]): F[Step[F, String, Step[F, Row, A]]] =
-        F.pure(doneOrLoop(DelimitedParser(format, bufferSize))(step))
+        F.pure(doneOrLoop(DelimitedParser(format, bufferSize, maxCharsPerRow))(step))
 
       private[this] def doneOrLoop[A](parser: DelimitedParser)(step: Step[F, Row, A]): Step[F, String, Step[F, Row, A]] = {
         if (step.isDone) {


### PR DESCRIPTION
This allows a user to specify a hard limit on the size of any given row. This is purely for safety; there is no technical reason to set a hard limit and the default is to allow rows of any size.