### PR TITLE
Scala, SBT, and iteratee.io version updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
+sudo: false
 language: scala
 scala:
-  - 2.11.7
-  - 2.10.5
+  - 2.10.6
+  - 2.11.11
 jdk:
-  - oraclejdk7
   - openjdk7
-sudo: false
+  - oraclejdk7
+  - oraclejdk8
+matrix:
+  include:
+  - scala: 2.12.2
+    jdk: oraclejdk8
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage test
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ organization in ThisBuild := "net.tixxit"
 
 licenses in ThisBuild += ("BSD-style" -> url("http://opensource.org/licenses/MIT"))
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.11.11"
 
-crossScalaVersions in ThisBuild := Seq("2.10.5", "2.11.8")
+crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2")
 
 scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds", "-optimize")
 
@@ -17,10 +17,8 @@ import com.typesafe.sbt.site.SitePlugin.autoImport._
 lazy val root = project.
   in(file(".")).
   aggregate(delimitedCore, delimitedIteratee).
-  enablePlugins(SiteScaladocPlugin).
+  enablePlugins(GhpagesPlugin, ScalaUnidocPlugin, SiteScaladocPlugin).
   settings(Publish.skip: _*).
-  settings(unidocSettings: _*).
-  settings(ghpages.settings: _*).
   settings(
     name := "delimited",
     addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in SiteScaladoc),

--- a/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
+++ b/delimited-iteratee/src/main/scala/net/tixxit/delimited/iteratee/Delimited.scala
@@ -3,10 +3,15 @@ package iteratee
 
 import java.nio.charset.{ Charset, StandardCharsets }
 
-import cats.{ Applicative, Monad }
+import cats.{ Applicative, Monad, MonadError }
+import cats.data.NonEmptyList
+import cats.instances.either._
+import cats.instances.vector._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
 
 import io.iteratee._
-import io.iteratee.internal.{ Step, Input }
+import io.iteratee.internal.Step
 
 /**
  * A collection of [[Iteratee]]s and [[Enumeratee]]s for working with delimited
@@ -33,31 +38,13 @@ object Delimited {
    */
   final def inferDelimitedFormat[F[_]](
     bufferSize: Int = DelimitedParser.BufferSize
-  )(implicit F: Applicative[F]): Iteratee[F, String, DelimitedFormat] = {
-    def stepWith(acc: Vector[String], length: Int): Step[F, String, DelimitedFormat] =
-      if (length >= bufferSize) {
-        val chunk = acc.mkString
-        val format = DelimitedFormat.Guess(chunk)
-        Step.done(format)
-      } else {
-        new Step.PureCont[F, String, DelimitedFormat] {
-          final def onEl(e: String): Step[F, String, DelimitedFormat] =
-            stepWith(acc :+ e, length + e.length)
-
-          final def onChunk(h1: String, h2: String, t: Vector[String]): Step[F, String, DelimitedFormat] = {
-            val tLength = t.foldLeft(0) { (n, e) => n + e.length }
-            val newLength = length + h1.length + h2.length + tLength
-            stepWith((acc :+ h1 :+ h2) ++ t, newLength)
-          }
-
-          final def run: F[DelimitedFormat] = {
-            F.pure(DelimitedFormat.Guess(acc.mkString))
-          }
-        }
-      }
-
-    Iteratee.fromStep(stepWith(Vector.empty, 0))
-  }
+  )(implicit F: Monad[F]): Iteratee[F, String, DelimitedFormat] =
+    Enumeratee.scan[F, String, (Vector[String], Int)]((Vector.empty[String], 0)) {
+      case ((acc, length), input) => (acc :+ input, length + input.length)
+    }.andThen(Enumeratee.takeWhile(_._2 <= bufferSize)).into(Iteratee.last).map {
+      case Some((acc, _)) => DelimitedFormat.Guess(acc.mkString)
+      case None           => DelimitedFormat.Guess("")
+    }
 
   /**
    * An [[Enumeratee]] that parses chunks of character data from a delimited
@@ -68,11 +55,11 @@ object Delimited {
    * @param maxCharsPerRow hard limit on the # of chars in a row, or 0 if there
    *                       is no limit
    */
-  final def parseString[F[_]](
+  final def parseString[F[_], E >: DelimitedError](
     format: DelimitedFormatStrategy,
     bufferSize: Int = DelimitedParser.BufferSize,
     maxCharsPerRow: Int = 0
-  )(implicit F: Applicative[F]): Enumeratee[F, String, Row] = {
+  )(implicit F: MonadError[F, E]): Enumeratee[F, String, Row] = {
     new Enumeratee[F, String, Row] {
       def apply[A](step: Step[F, Row, A]): F[Step[F, String, Step[F, Row, A]]] =
         F.pure(doneOrLoop(DelimitedParser(format, bufferSize, maxCharsPerRow))(step))
@@ -80,45 +67,34 @@ object Delimited {
       private[this] def doneOrLoop[A](parser: DelimitedParser)(step: Step[F, Row, A]): Step[F, String, Step[F, Row, A]] = {
         if (step.isDone) {
           val (leftOver, _) = parser.reset
-          Step.doneWithLeftoverInput[F, String, Step[F, Row, A]](step, Input.el(leftOver))
+          Step.doneWithLeftovers[F, String, Step[F, Row, A]](step, Seq(leftOver))
         } else {
           stepWith(parser, step)
         }
       }
 
-      private[this] def stepWith[A](
-        parser: DelimitedParser,
-        step: Step[F, Row, A]
-      ): Step[F, String, Step[F, Row, A]] = {
+      private[this] def stepWith[A](parser: DelimitedParser, step: Step[F, Row, A]): Step[F, String, Step[F, Row, A]] =
         new Step.Cont[F, String, Step[F, Row, A]] {
           final def run: F[Step[F, Row, A]] = parseChunk(None)._2
 
-          final def onEl(chunk: String): F[Step[F, String, Step[F, Row, A]]] = {
+          final def feedEl(chunk: String): F[Step[F, String, Step[F, Row, A]]] = {
             val (nextParser, nextStep) = parseChunk(Some(chunk))
             F.map(nextStep)(doneOrLoop(nextParser))
           }
 
-          final def onChunk(h1: String, h2: String, t: Vector[String]): F[Step[F, String, Step[F, Row, A]]] = {
+          final protected def feedNonEmpty(chunk: Seq[String]): F[Step[F, String, Step[F, Row, A]]] = {
             val bldr = new StringBuilder
-            bldr.append(h1)
-            bldr.append(h2)
-            t.foreach(bldr.append)
-            val chunk = bldr.toString
-            onEl(chunk)
+            chunk.foreach(bldr.append)
+            feedEl(bldr.toString)
           }
 
           private[this] def parseChunk(chunk: Option[String]): (DelimitedParser, F[Step[F, Row, A]]) = {
             val (nextParser, results) = parser.parseChunk(chunk)
-            val rows = results.map(_.right.get)
-            val nextStep = rows match {
-              case Vector() => F.pure(step)
-              case Vector(e) => step.feedEl(e)
-              case _ => step.feedChunk(rows(0), rows(1), rows.drop(2))
-            }
+            val rows = results.sequenceU.fold(F.raiseError, F.pure)
+            val nextStep = rows.flatMap(step.feed)
             (nextParser, nextStep)
           }
         }
-      }
     }
   }
 }

--- a/delimited-iteratee/src/test/scala/net/tixxit/delimited/iteratee/DelimitedSpec.scala
+++ b/delimited-iteratee/src/test/scala/net/tixxit/delimited/iteratee/DelimitedSpec.scala
@@ -3,9 +3,11 @@ package iteratee
 
 import java.io.{ BufferedWriter, ByteArrayInputStream, File, FileOutputStream, OutputStreamWriter }
 
-import scala.util.Random
+import scala.util.{ Random, Success, Try }
 
 import cats.{ Id, Eval }
+import cats.data.EitherT
+import cats.instances.try_._
 
 import io.iteratee.{ Enumeratee, Enumerator, Iteratee }
 
@@ -34,15 +36,15 @@ class DelimitedSpec extends WordSpec with Matchers with Checkers {
 
   "formatString" should {
     "render empty file" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.id._
       val parts = enumList(Nil)
-        .mapE(Delimited.formatString(DelimitedFormat.CSV))
-        .run(Iteratee.consume)
+        .through(Delimited.formatString(DelimitedFormat.CSV))
+        .into(Iteratee.consume)
       parts shouldBe Vector()
     }
 
     "render delimited file" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.id._
       val rows = Stream(
         Row("a", "b", "c"),
         Row("d", ",", "a,b,c"),
@@ -51,44 +53,44 @@ class DelimitedSpec extends WordSpec with Matchers with Checkers {
         Row("1", "2", "3")
       )
       val mkString: Iteratee[Id, String, String] =
-        Iteratee.consume.map(_.mkString)
+        Iteratee.consume[Id, String].map(_.mkString)
 
-      val file1 = Enumerator.enumStream(rows, chunkSize = 2)
-        .mapE(Delimited.formatString(DelimitedFormat.CSV))
-        .run(mkString)
+      val file1 = Enumerator.enumStream[Id, Row](rows, chunkSize = 2)
+        .through(Delimited.formatString(DelimitedFormat.CSV))
+        .into(mkString)
       file1 shouldBe "a,b,c\nd,\",\",\"a,b,c\"\n\"\"\"blah\"\"\",x,1234\n,q,r\n1,2,3"
-      val file2 = Enumerator.enumStream(rows, chunkSize = 2)
-        .mapE(Delimited.formatString(DelimitedFormat.TSV))
-        .run(mkString)
+      val file2 = Enumerator.enumStream[Id, Row](rows, chunkSize = 2)
+        .through(Delimited.formatString(DelimitedFormat.TSV))
+        .into(mkString)
       file2 shouldBe "a\tb\tc\nd\t,\ta,b,c\n\"\"\"blah\"\"\"\tx\t1234\n\tq\tr\n1\t2\t3"
       val format = DelimitedFormat("-", quote = "%", rowDelim = RowDelim("|"))
-      val file3 = Enumerator.enumStream(rows, chunkSize = 2)
-        .run(mkString.through(Delimited.formatString(format)))
+      val file3 = Enumerator.enumStream[Id, Row](rows, chunkSize = 2)
+        .into(mkString.through(Delimited.formatString(format)))
       file3 shouldBe "a-b-c|d-,-a,b,c|\"blah\"-x-1234|-q-r|1-2-3"
     }
   }
 
   "inferDelimitedFormat" should {
     "infer default format when no input given" in {
-      import io.iteratee.pure._
-      val format = enumList(Nil).run(Delimited.inferDelimitedFormat())
+      import io.iteratee.modules.id._
+      val format = enumList(Nil).into(Delimited.inferDelimitedFormat())
       val expected = DelimitedFormat.Guess("")
       format shouldBe expected
     }
 
     "output guess when zipped with parser" in {
-      import io.iteratee.pure._
-      val parser: Iteratee[Id, String, Vector[Row]] =
-        Iteratee.consume.through(Delimited.parseString(DelimitedFormat.Guess))
+      import io.iteratee.modules.try_._
+      val parser: Iteratee[Try, String, Vector[Row]] =
+        Delimited.parseString[Try, Throwable](DelimitedFormat.Guess).into(Iteratee.consume)
 
       List(20, 100).foreach { bufferSize =>
-        val iteratee: Iteratee[Id, String, (DelimitedFormat, Vector[Row])] =
+        val iteratee: Iteratee[Try, String, (DelimitedFormat, Vector[Row])] =
           Delimited.inferDelimitedFormat(bufferSize = bufferSize).zip(parser)
-        val chunks = Enumerator.enumStream[Id, String](
+        val chunks = Enumerator.enumStream[Try, String](
           Stream("a,b,", "c\nd,e", ",", "f\n", "g,h,i\nj,k", ",", "l"),
           chunkSize = 2
         )
-        val (format, rows) = chunks.run(iteratee)
+        val Success((format, rows)) = chunks.into(iteratee)
         format.separator shouldBe ","
         format.rowDelim.value shouldBe "\n"
         rows shouldBe Vector(Row("a", "b", "c"), Row("d", "e", "f"), Row("g", "h", "i"), Row("j", "k", "l"))
@@ -98,52 +100,54 @@ class DelimitedSpec extends WordSpec with Matchers with Checkers {
 
   "parseString" should {
     "parse no chunks" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.try_._
       val rows = enumList[String](Nil)
-        .mapE(Delimited.parseString[Id](DelimitedFormat.Guess))
-        .run(Iteratee.consume)
-      rows shouldBe Vector.empty[Row]
+        .through(Delimited.parseString[Try, Throwable](DelimitedFormat.Guess))
+        .into(Iteratee.consume)
+      rows shouldBe Success(Vector.empty[Row])
     }
 
     "parse empty chunk" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.try_._
       val rows = enumList[String]("" :: Nil)
-        .mapE(Delimited.parseString[Id](DelimitedFormat.CSV))
-        .run(Iteratee.consume)
-      rows shouldBe Vector.empty[Row]
+        .through(Delimited.parseString[Try, Throwable](DelimitedFormat.CSV))
+        .into(Iteratee.consume)
+      rows shouldBe Success(Vector.empty[Row])
     }
 
     "parse only 2 rows" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.try_._
       val rows = enumList[String](List("a,b,", "c\nd,e", ",", "f\n", "g,h,i\nj,k", "l"))
-        .mapE(Delimited.parseString[Id](DelimitedFormat.CSV))
-        .run(Iteratee.take(2))
-      rows shouldBe Vector(Row("a", "b", "c"), Row("d", "e", "f"))
+        .through(Delimited.parseString[Try, Throwable](DelimitedFormat.CSV))
+        .into(Iteratee.take(2))
+      rows shouldBe Success(Vector(Row("a", "b", "c"), Row("d", "e", "f")))
     }
 
     "parse header, then rest" in {
-      import io.iteratee.pure._
+      import io.iteratee.modules.try_._
 
-      val withHeader: Iteratee[Id, Row, (Row, Vector[Row])] = for {
+      val withHeader: Iteratee[Try, Row, (Row, Vector[Row])] = for {
         header <- Iteratee.head
         rest   <- Iteratee.consume
       } yield (header.get -> rest)
       val rows = enumList[String](List("a,b,", "c\nd,e", ",", "f\n", "g,h,i"))
-        .mapE(Delimited.parseString[Id](DelimitedFormat.CSV))
-        .run(withHeader)
-      rows shouldBe (Row("a", "b", "c"), Vector(Row("d", "e", "f"), Row("g", "h", "i")))
+        .through(Delimited.parseString[Try, Throwable](DelimitedFormat.CSV))
+        .into(withHeader)
+      rows shouldBe Success((Row("a", "b", "c"), Vector(Row("d", "e", "f"), Row("g", "h", "i"))))
     }
 
     "parse larges files, in chunks" in {
-      import io.iteratee.eval._
+      import io.iteratee.modules.eitherT._
+
+      type EvalOr[A] = EitherT[Eval, Throwable, A]
 
       // This is basically my paranoid test case. So, we have a large
       // delimited file (guaranteed to pass inference buffer size) that
       // is split into a bunch of small chunks. We then sequence our
       // enumeratee through an Iteratee for good measure to ensure our
       // EOF behaviour works as expected.
-      val grouped = Delimited.parseString[Eval](DelimitedFormat.Guess).andThen(Enumeratee.grouped(2))
-      val consumeGroups = Iteratee.consume[Eval, Vector[Row]].through(grouped)
+      val grouped = Delimited.parseString[EvalOr, Throwable](DelimitedFormat.Guess).andThen(Enumeratee.grouped(2))
+      val consumeGroups = grouped.into(Iteratee.consume)
       val expected = (1 to 100000)
         .map(_.toString)
         .grouped(3)
@@ -151,9 +155,9 @@ class DelimitedSpec extends WordSpec with Matchers with Checkers {
         .toVector
       val file = expected.map(_.render(DelimitedFormat.CSV)).mkString("\n")
       val actual = Enumerator
-        .enumStream[Eval, String](split(file).toStream, chunkSize = 1)
-        .run(consumeGroups).value.flatten
-      actual shouldBe expected
+        .enumStream[EvalOr, String](split(file).toStream, chunkSize = 1)
+        .into(consumeGroups).value.value.right.map(_.flatten)
+      actual shouldBe Right(expected)
     }
   }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Deps {
   object V {
-    val iteratee   = "0.5.0"
+    val iteratee   = "0.12.0"
     val scalaTest  = "3.0.3"
     val scalaCheck = "1.13.5"
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -3,8 +3,8 @@ import sbt._
 object Deps {
   object V {
     val iteratee   = "0.5.0"
-    val scalaTest  = "2.2.6"
-    val scalaCheck = "1.12.5"
+    val scalaTest  = "3.0.3"
+    val scalaCheck = "1.13.5"
   }
 
   val iteratee   = "io.iteratee"    %% "iteratee-core" % V.iteratee

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"       % "1.0.0")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"   % "1.0.0")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"  % "0.5.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"       % "0.2.6")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-site"      % "1.0.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"   % "0.5.4")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage" % "1.1.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"    % "0.3.3")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"       % "1.0.1")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"   % "1.0.5")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"  % "1.1")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"       % "0.2.25")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-site"      % "1.2.0")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"   % "0.6.0")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"    % "0.4.0")


### PR DESCRIPTION
The Scala and SBT plugin updates are pretty straightforward. I've also updated iteratee.io, though, which is a little more dramatic, since the API has changed a bit since 0.5.0. `inferDelimitedFormat` in particular is a lot nicer with the new `scan` and `last` coming in iteratee.io 0.12.0.

I've made one substantial change: `parseString` no longer throws exceptions on delimiter errors, but instead fails safely in the enumeratee's context. This means that context needs to have a `MonadError` instance, which means a lot of the tests that were written against `Id` or `Eval` had to be changed. I'm happy to roll this part back if you'd prefer the old behavior.

~~This PR will fail at the moment, since it depends on a 0.12.0 snapshot for iteratee.io, which I don't publish, but I'm planning to publish 0.12.0 later tonight or early tomorrow morning. I also forgot that I was going to add Scala.js support along with 2.12.0—I could either do that here or in a follow-up PR.~~

Okay, this is ready for review—0.12.0 is out and I think Scala.js should be a separate PR.

