### PR TITLE
Turn off -optimize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ sudo: false
 language: scala
 scala:
   - 2.10.6
-  - 2.11.11
+  - 2.11.12
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
 matrix:
   include:
-  - scala: 2.12.2
+  - scala: 2.12.6
     jdk: oraclejdk8
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage test

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ organization in ThisBuild := "net.tixxit"
 
 licenses in ThisBuild += ("BSD-style" -> url("http://opensource.org/licenses/MIT"))
 
-scalaVersion in ThisBuild := "2.11.11"
+scalaVersion in ThisBuild := "2.11.12"
 
-crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2")
+crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.12", "2.12.6")
 
 scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds")
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion in ThisBuild := "2.11.11"
 
 crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2")
 
-scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds", "-optimize")
+scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds")
 
 maxErrors in ThisBuild := 5
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"       % "1.0.1")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"   % "1.0.5")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"  % "1.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"       % "0.2.25")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-site"      % "1.2.0")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"   % "0.6.0")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"    % "0.4.0")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"       % "1.1.1")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"   % "1.0.8")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"  % "2.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"       % "0.3.4")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-site"      % "1.3.2")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"   % "0.6.2")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"    % "0.4.1")


### PR DESCRIPTION
We're running into issues trying to use delimited on later 2.12 versions while the library is built on 2.12.2, because inlining breaks compatibility between Scala patch versions. 

Quick benchmark run to show that removing the flag doesn't have a catastrophic impact on performance:

Before:
```
Benchmark                                 Mode  Cnt     Score     Error  Units
DelimitedParserBenchmark.parseNarrowTSV  thrpt   25  1427.362 ± 110.572  ops/s
DelimitedParserBenchmark.parseWideTSV    thrpt   25    44.284 ±  10.658  ops/s
```

After:
```
Benchmark                                 Mode  Cnt     Score     Error  Units
DelimitedParserBenchmark.parseNarrowTSV  thrpt   25  1406.817 ± 199.414  ops/s
DelimitedParserBenchmark.parseWideTSV    thrpt   25    50.875 ±   7.101  ops/s
```

I've also bumped a few patch versions.