### PR TITLE
DelimitedParser.parseRow

### DIFF
--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedParser.scala
@@ -146,4 +146,25 @@ object DelimitedParser {
   ): DelimitedParser = {
     parser.DelimitedParserImpl(format, bufferSize, maxCharsPerRow)
   }
+
+  /**
+   * Parses a single row of a delimited file. This usually shouldn't be used to
+   * parse a file, but it is useful in constrained environments where the rows
+   * are pre-parsed already and all the state management of a `DelimitedParser`
+   * instance isn't needed.
+   *
+   * This method expects exactly 1 row. This row may have the row delimiter at
+   * the end. If a row is successfully parsed, but more text input remains,
+   * then this will return an error.
+   *
+   * For example, many big data systems (eg Cascading, Scalding) has text-line
+   * based input formats, upon which TSV/CSV parsing can be built. In these
+   * cases, the rows are supplied to the mapper, so we don't need any state
+   * management.
+   *
+   * @param format the format used to parse the row
+   * @param row    the text row, without any row-delimiters
+   */
+  def parseRow(format: DelimitedFormat, row: String): Either[DelimitedError, Row] =
+    parser.DelimitedParserImpl.parseRow(format, row)
 }

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
@@ -133,7 +133,7 @@ object DelimitedParserImpl {
       case (_, Instr.Fail(message, pos)) =>
         Left(DelimitedError(message, 0, pos, row, 1, pos + 1))
       case (_, Instr.NeedInput | Instr.Resume | Instr.Done) =>
-        Left(DelimitedError("malformed row", 0, 0, row, 1, 1))
+        Left(DelimitedError("empty row", 0, 0, row, 1, 1))
     }
   }
 

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/DelimitedParserImpl.scala
@@ -122,6 +122,21 @@ object DelimitedParserImpl {
     DelimitedParserImpl(format, ParserState.ParseRow(0L, 0L, Input.init("")), None, 1L, bufferSize, maxCharsPerRow)
   }
 
+  def parseRow(format: DelimitedFormat, row: String): Either[DelimitedError, Row] = {
+    val s0 = ParserState.ParseRow(0L, 0L, Input.last(row))
+    DelimitedParserImpl.parse(format)(s0) match {
+      case (s, Instr.EmitRow(row)) if s.rowStart == s.input.data.length =>
+        Right(row)
+      case (s, Instr.EmitRow(_)) =>
+        Left(DelimitedError("unexpected start of new row",
+                            0, s.rowStart, row, 1, s.rowStart + 1))
+      case (_, Instr.Fail(message, pos)) =>
+        Left(DelimitedError(message, 0, pos, row, 1, pos + 1))
+      case (_, Instr.NeedInput | Instr.Resume | Instr.Done) =>
+        Left(DelimitedError("malformed row", 0, 0, row, 1, 1))
+    }
+  }
+
   def parse(format: DelimitedFormat)(state: ParserState): (ParserState, Instr) = {
     import format._
 

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
@@ -96,4 +96,7 @@ final class Input private (
 object Input {
   def init(str: String): Input =
     new Input(0, str, false, 0)
+
+  def last(str: String): Input =
+    new Input(0, str, true, 0)
 }

--- a/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedSpec.scala
+++ b/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedSpec.scala
@@ -294,5 +294,13 @@ class DelimitedParserSpec extends WordSpec with Matchers with Checkers {
         }
       }
     }
+
+    "fails to parse empty row" in {
+      DelimitedParser.parseRow(DelimitedFormat.CSV, "") match {
+        case Right(_) => fail("expected failure")
+        case Left(error) =>
+          assert(error.message.contains("empty"))
+      }
+    }
   }
 }

--- a/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedSpec.scala
+++ b/delimited-core/src/test/scala/net/tixxit/delimited/DelimitedSpec.scala
@@ -251,4 +251,48 @@ class DelimitedParserSpec extends WordSpec with Matchers with Checkers {
       }
     }
   }
+
+  "parseRow" should {
+    "parse single row" in {
+      val rowsAndResults = List(
+        "a,b,c" -> Row("a", "b", "c"),
+        "a b, c d ,e " -> Row("a b", " c d ", "e "),
+        "a,\"b,\"\"d\"\",e\",f" -> Row("a", "b,\"d\",e", "f"),
+        "a,\"b\",\"c\nd\"" -> Row("a", "b", "c\nd"),
+        "a,b,c\n" -> Row("a", "b", "c"),
+        "a b, c d ,e \r\n" -> Row("a b", " c d ", "e "),
+        "a,\"b,\"\"d\"\",e\",f\n" -> Row("a", "b,\"d\",e", "f"),
+        "a,\"b\",\"c\nd\"\r\n" -> Row("a", "b", "c\nd"))
+      rowsAndResults.foreach { case (row, expected) =>
+        assert(DelimitedParser.parseRow(DelimitedFormat.CSV, row) == Right(expected))
+      }
+    }
+
+    "fail on un-terminated quote" in {
+      val badRows = List(
+        "a,b,\"c",
+        "a,\"b\"\",c\n")
+      badRows.foreach { row =>
+        DelimitedParser.parseRow(DelimitedFormat.CSV, row) match {
+          case Right(_) => fail("expected failure")
+          case Left(error) =>
+            assert(error.message.contains("quote"))
+        }
+      }
+    }
+
+    "fail on extra rows" in {
+      val badRows = List(
+        "a,b,c\nd,e",
+        "a,b,c\nd,e,f\n",
+        "a,\"b,\"\"d\"\",e\",f\nand more")
+      badRows.foreach { row =>
+        DelimitedParser.parseRow(DelimitedFormat.CSV, row) match {
+          case Right(_) => fail("expected failure")
+          case Left(error) =>
+            assert(error.message.contains("unexpected start of new row"))
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This adds a new method, `DelimitedParser.parseRow(format, row)`, that can be used to parse a single row of data, without any parser state management. This is mainly to make using the lib easier when you are working in a framework where the rows are pre-parsed.