### PR TITLE
Add maxSep optimization

### DIFF
--- a/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedFormat.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/DelimitedFormat.scala
@@ -100,6 +100,19 @@ case class DelimitedFormat(
     text.replace(quote, escapedQuote)
 
   /**
+   * any character > maxSep cannot be a delimiter or separator
+   */
+  val maxSep: Char = {
+    val zero = 0.toChar
+    def get(str: String) = if (str.isEmpty) zero else (str.charAt(0).toInt).toChar
+    val c0 = get(separator)
+    val c1 = get(primaryRowDelim)
+    val c2 = if (c0 < c1) c1 else c0
+    val c3 = if (secondaryRowDelim eq null) zero else get(secondaryRowDelim)
+    if (c2 < c3) c3 else c2
+  }
+
+  /**
    * If `text` starts with a quote, then this removes the wrapping quotes, then
    * unescapes the resulting text. If text does not start with a quote, then it
    * is returned unchanged.

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
@@ -58,14 +58,6 @@ final class Input private (
   def substring(from: Long, until: Long): String =
     data.substring(check(from), check(until))
 
-  def indexOf(str: String, from: Long): Long = {
-    val idx = data.indexOf(str, check(from))
-    if (idx < 0) -1L
-    else {
-      idx.toLong + offset
-    }
-  }
-
   /**
    * Returns an `Input` whose `mark` is at the given position.
    */

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
@@ -58,6 +58,14 @@ final class Input private (
   def substring(from: Long, until: Long): String =
     data.substring(check(from), check(until))
 
+  def indexOf(str: String, from: Long): Long = {
+    val idx = data.indexOf(str, check(from))
+    if (idx < 0) -1L
+    else {
+      idx.toLong + offset
+    }
+  }
+
   /**
    * Returns an `Input` whose `mark` is at the given position.
    */

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/InputBuffer.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/InputBuffer.scala
@@ -17,6 +17,15 @@ final class InputBuffer(input: Input) {
 
   def getChar(): Char = chunk.charAt(pos)
   def advance(i: Int): Unit = pos += i
+
+  // advance while characters are > the given character
+  def advanceGT(c: Char): Long  = {
+    while (pos < clen && (chunk.charAt(pos) > c)) {
+      pos += 1
+    }
+    pos.toLong + input.offset
+  }
+
   def retreat(i: Int): Unit = pos -= i
   def endOfInput(): Boolean = pos >= clen
   def endOfFile(): Boolean = endOfInput() && input.isLast


### PR DESCRIPTION
This adds a considerable optimization: in non-escaped strings, we can check to see if the character is bigger than all separators and delimiters and skip ahead while that's true. For number fields or non-quoted fields this results in a huge speedup:
```
this PR:
[info] Benchmark                                 Mode  Cnt   Score   Error  Units
[info] DelimitedParserBenchmark.parseNarrowTSV  thrpt    3  34.223 ± 3.519  ops/s
[info] DelimitedParserBenchmark.parseWideTSV    thrpt    3   1.371 ± 0.049  ops/s

master:
[info] Benchmark                                 Mode  Cnt  Score   Error  Units
[info] DelimitedParserBenchmark.parseNarrowTSV  thrpt    3  7.993 ± 0.037  ops/s
[info] DelimitedParserBenchmark.parseWideTSV    thrpt    3  0.275 ± 0.041  ops/s
```

This is 325% to 413% faster depending on the width for non-escaped cells.