### PR TITLE
Add a comparison benchmark to SimpleFlatMapper

### DIFF
--- a/delimited-benchmark/build.sbt
+++ b/delimited-benchmark/build.sbt
@@ -1,3 +1,7 @@
 name := "delimited-benchmark"
 
 enablePlugins(JmhPlugin)
+
+libraryDependencies ++= Seq(
+  Deps.simpleFlatMapperCsv
+)

--- a/delimited-benchmark/src/main/scala/net/tixxit/delimited/benchmark/DelimitedParserBenchmark.scala
+++ b/delimited-benchmark/src/main/scala/net/tixxit/delimited/benchmark/DelimitedParserBenchmark.scala
@@ -1,7 +1,9 @@
 package net.tixxit.delimited
 package benchmark
 
+import java.io.StringReader
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+import org.simpleflatmapper.csv.CsvParser
 
 import net.tixxit.delimited.parser._
 
@@ -9,13 +11,33 @@ class DelimitedParserBenchmark {
   import DelimitedParserBenchmark._
 
   @Benchmark
-  def parseNarrowTSV(data: Data): Vector[Either[DelimitedError, Row]] = {
-    DelimitedParser(data.format).parseString(data.narrowTsv)
+  def parseNarrowCSV(data: Data): Vector[Either[DelimitedError, Row]] = {
+    DelimitedParser(data.format).parseString(data.narrowCsv)
   }
 
   @Benchmark
-  def parseWideTSV(data: Data): Vector[Either[DelimitedError, Row]] = {
-    DelimitedParser(data.format).parseString(data.wideTsv)
+  def parseWideCSV(data: Data): Vector[Either[DelimitedError, Row]] = {
+    DelimitedParser(data.format).parseString(data.wideCsv)
+  }
+
+  @Benchmark
+  def parseNarrowCSVSimpleFlatMapper(data: Data): Vector[Either[DelimitedError, Row]] = {
+    val iter = CsvParser.iterator(new StringReader(data.narrowCsv))
+    val bldr = Vector.newBuilder[Either[DelimitedError, Row]]
+    while (iter.hasNext()) {
+      bldr += Right(Row.fromArray(iter.next()))
+    }
+    bldr.result()
+  }
+
+  @Benchmark
+  def parseWideCSVSimpleFlatMapper(data: Data): Vector[Either[DelimitedError, Row]] = {
+    val iter = CsvParser.iterator(new StringReader(data.wideCsv))
+    val bldr = Vector.newBuilder[Either[DelimitedError, Row]]
+    while (iter.hasNext()) {
+      bldr += Right(Row.fromArray(iter.next()))
+    }
+    bldr.result()
   }
 }
 
@@ -23,13 +45,13 @@ object DelimitedParserBenchmark {
 
   @State(Scope.Benchmark)
   class Data {
-    val format: DelimitedFormat = DelimitedFormat.TSV
+    val format: DelimitedFormat = DelimitedFormat.CSV
     val narrowRow: Row = Row("aaaaaa", "aa", "aaaaaaaaaaaaaaaaaaaaaaaaa")
-    val narrowTsv: String =
+    val narrowCsv: String =
       List.fill(1000)(narrowRow.render(format)).mkString(format.rowDelim.value)
 
     val wideRow: Row = Row(List.fill(30)(narrowRow).flatMap(_.toList): _*)
-    val wideTsv: String =
+    val wideCsv: String =
       List.fill(1000)(wideRow.render(format)).mkString(format.rowDelim.value)
   }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -12,4 +12,5 @@ object Deps {
   val scalaTest  = "org.scalatest"  %% "scalatest"     % V.scalaTest  % "test"
   val scalaCheck = "org.scalacheck" %% "scalacheck"    % V.scalaCheck % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-14"    % V.scalaTestPlusCheck % "test"
+  val simpleFlatMapperCsv = "org.simpleflatmapper" % "sfm-csv" % "8.2.3"
 }


### PR DESCRIPTION
We do okay, compared to this library (more than 1/2 as fast).

This was the second highest performing CSV parser according to this benchmark (only by a bit, and I didn't immediately see the github page for the first):

https://github.com/uniVocity/csv-parsers-comparison
```
[info] Benchmark                                                 Mode  Cnt     Score      Error  Units
[info] DelimitedParserBenchmark.parseNarrowCSV                  thrpt    3  5173.479 ±  498.430  ops/s
[info] DelimitedParserBenchmark.parseNarrowCSVSimpleFlatMapper  thrpt    3  9427.354 ± 1965.853  ops/s
[info] DelimitedParserBenchmark.parseWideCSV                    thrpt    3   268.583 ±   94.298  ops/s
[info] DelimitedParserBenchmark.parseWideCSVSimpleFlatMapper    thrpt    3   410.731 ±   97.489  ops/s
```

Just guessing based on other comparisons, this puts delimited in the middle to top middle of the pack, which is very good for a parser with a fully immutable API and state management.

The main goal here is to have an idea what the upper bound might be.