### PR TITLE
Optimize isFlag more

### DIFF
--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/Input.scala
@@ -27,12 +27,6 @@ final class Input private (
   val isLast: Boolean,
   val mark: Long
 ) {
-  private def check(i: Long): Int = if ((i < offset) || (i > (offset + data.length))) {
-    throw new IndexOutOfBoundsException(i.toString)
-  } else {
-    (i - offset).toInt
-  }
-
   /**
    * Returns the character data between `mark` and `limit`. This is equivalent
    * to calling `input.substring(input.mark, input.limit)`.
@@ -43,7 +37,8 @@ final class Input private (
    * Returns the character at the given position. This method will do some
    * aggressive bounds checking.
    */
-  def charAt(i: Long): Char = data.charAt(check(i))
+  def charAt(i: Long): Char =
+    data.charAt((i - offset).toInt)
 
   /**
    * Returns the index of the first position that cannot be read. If `isLast`
@@ -56,7 +51,7 @@ final class Input private (
    * It is expected that `mark <= from <= until <= limit`.
    */
   def substring(from: Long, until: Long): String =
-    data.substring(check(from), check(until))
+    data.substring((from - offset).toInt, (until - offset).toInt)
 
   /**
    * Returns an `Input` whose `mark` is at the given position.

--- a/delimited-core/src/main/scala/net/tixxit/delimited/parser/InputBuffer.scala
+++ b/delimited-core/src/main/scala/net/tixxit/delimited/parser/InputBuffer.scala
@@ -30,8 +30,10 @@ final class InputBuffer(input: Input) {
   def endOfInput(): Boolean = pos >= clen
   def endOfFile(): Boolean = endOfInput() && input.isLast
 
-  def isFlag(str: String): Int = {
-    val slen = str.length
+  def isFlag(str: String): Int =
+    isFlag(str, str.length)
+
+  def isFlag(str: String, slen: Int): Int = {
 
     // there are a few cases:
     // 1. clen >= slen
@@ -58,29 +60,58 @@ final class InputBuffer(input: Input) {
     }
     */
 
-    var p = pos
-    var i = 0
-    var res = -2
-    while (res == -2) {
-      if (i >= slen) {
-        res = i
-      }
-      else if (p >= clen) {
+    if (slen == 1) {
+      // this is a common case
+      if (pos >= clen) {
         // we exhausted this chunk
-        res = if (input.isLast) 0 else -1
+        if (input.isLast) 0 else -1
       }
-      else if (str.charAt(i) != chunk.charAt(p)) {
-        res = 0
+      else if (str.charAt(0) != chunk.charAt(pos)) {
+        0
       }
-
-      i += 1
-      p += 1
+      else 1
     }
-    res
+    else {
+      if (clen - pos >= slen) {
+        // the maximum i can be is slen,
+        // so if clen - pos >= slen, we can't exhaust
+        if (chunk.startsWith(str, pos)) slen
+        else 0
+      }
+      else {
+        var p = pos
+        var i = 0
+        // we know that clen - pos < slen
+        // so we cannot contain the entire string
+        // but we could have the beggining of str
+        // and then run out of input
+        // we can exhaust the input
+        while (true) {
+          if (p >= clen) {
+            // we exhausted this chunk
+            return if (input.isLast) 0 else -1
+          }
+          else if (str.charAt(i) != chunk.charAt(p)) {
+            return 0
+          }
+          else {
+            i += 1
+            p += 1
+          }
+        }
+        // unreachable
+        Int.MinValue
+      }
+    }
   }
 
   def eitherFlag(f1: String, f2: String): Int = {
     val i = isFlag(f1)
     if (i == 0 && (f2 ne null)) isFlag(f2) else i
+  }
+
+  def eitherFlag(f1: String, f1Len: Int, f2: String, f2Len: Int): Int = {
+    val i = isFlag(f1, f1Len)
+    if (i == 0 && (f2 ne null)) isFlag(f2, f2Len) else i
   }
 }


### PR DESCRIPTION
Using yourkit while the benchmarks are running I did a few things:

1. cache the length of all the delimiter strings. We seem to call .length on them at least once, pass the length into isFlag
2. in the common case of len == 1 strings, handle more directly
3. in the common case we can't exhaust the input, just use startsWith
4. remove check from Input, we don't go out of bounds, and if we did chatAt throws the same exception.

This results in running 54% as fast as simpleflatmapper for narrow CSV and 78% as fast for the wide CSV:
```
[info] Benchmark                                                 Mode  Cnt     Score    Error  Units
[info] DelimitedParserBenchmark.parseNarrowCSV                  thrpt   10  5232.065 ± 11.887  ops/s
[info] DelimitedParserBenchmark.parseNarrowCSVSimpleFlatMapper  thrpt   10  9700.296 ± 24.419  ops/s
[info] DelimitedParserBenchmark.parseWideCSV                    thrpt   10   317.298 ±  1.784  ops/s
[info] DelimitedParserBenchmark.parseWideCSVSimpleFlatMapper    thrpt   10   408.165 ±  1.662  ops/s
```